### PR TITLE
👷✨ Fix the spelling of FALSE in a few places

### DIFF
--- a/R/ShowRegTable.R
+++ b/R/ShowRegTable.R
@@ -7,7 +7,7 @@
 ##' @param exp TRUE by default. You need to specify exp = FALSE if your model is has the indentity link function (linear regression, etc).
 ##' @param digits Number of digits to print for the main part.
 ##' @param pDigits Number of digits to print for the p-values.
-##' @param printToggle Whether to print the output. If FLASE, no output is created, and a matrix is invisibly returned.
+##' @param printToggle Whether to print the output. If FALSE, no output is created, and a matrix is invisibly returned.
 ##' @param quote Whether to show everything in quotes. The default is FALSE. If TRUE, everything including the row and column names are quoted so that you can copy it to Excel easily.
 ##' @param ciFun Function used for calculation. \code{confint} is the default. For generalized linear models this gives the profile likelihood-based calculation, which may take too much time for large models, use \code{confint.default} for simple normal approximation method (+/- 1.96 * standard error).
 ##' @return A matrix containing what you see is returned invisibly. You can capture it by assignment to an object.

--- a/R/print.CatTable.R
+++ b/R/print.CatTable.R
@@ -8,7 +8,7 @@
 ##' @param quote Whether to show everything in quotes. The default is FALSE. If TRUE, everything including the row and column names are quoted so that you can copy it to Excel easily.
 ##' @param missing Whether to show missing data information.
 ##' @param explain Whether to add explanation to the variable names, i.e., (\%) is added to the variable names when percentage is shown.
-##' @param printToggle Whether to print the output. If FLASE, no output is created, and a matrix is invisibly returned.
+##' @param printToggle Whether to print the output. If FALSE, no output is created, and a matrix is invisibly returned.
 ##' @param noSpaces Whether to remove spaces added for alignment. Use this option if you prefer to align numbers yourself in other software.
 ##' @param format The default is "fp" frequency (percentage). You can also choose from "f" frequency only, "p" percentage only, and "pf" percentage (frequency).
 ##' @param showAllLevels Whether to show all levels. FALSE by default, i.e., for 2-level categorical variables, only the higher level is shown to avoid redundant information.

--- a/R/print.ContTable.R
+++ b/R/print.ContTable.R
@@ -8,7 +8,7 @@
 ##' @param quote Whether to show everything in quotes. The default is FALSE. If TRUE, everything including the row and column names are quoted so that you can copy it to Excel easily.
 ##' @param missing Whether to show missing data information.
 ##' @param explain Whether to add explanation to the variable names, i.e., (mean (sd) or median [IQR]) is added to the variable names.
-##' @param printToggle Whether to print the output. If FLASE, no output is created, and a matrix is invisibly returned.
+##' @param printToggle Whether to print the output. If FALSE, no output is created, and a matrix is invisibly returned.
 ##' @param noSpaces Whether to remove spaces added for alignment. Use this option if you prefer to align numbers yourself in other software.
 ##' @param nonnormal A character vector to specify the variables for which the p-values should be those of nonparametric tests. By default all p-values are from normal assumption-based tests (oneway.test).
 ##' @param minMax Whether to use [min,max] instead of [p25,p75] for nonnormal variables. The default is FALSE.

--- a/R/print.TableOne.R
+++ b/R/print.TableOne.R
@@ -9,7 +9,7 @@
 ##' @param quote Whether to show everything in quotes. The default is FALSE. If TRUE, everything including the row and column names are quoted so that you can copy it to Excel easily.
 ##' @param missing Whether to show missing data information.
 ##' @param explain Whether to add explanation to the variable names, i.e., (\%) is added to the variable names when percentage is shown.
-##' @param printToggle Whether to print the output. If FLASE, no output is created, and a matrix is invisibly returned.
+##' @param printToggle Whether to print the output. If FALSE, no output is created, and a matrix is invisibly returned.
 ##' @param test Whether to show p-values. TRUE by default. If FALSE, only the numerical summaries are shown.
 ##' @param smd Whether to show standardized mean differences. FALSE by default. If there are more than one contrasts, the average of all possible standardized mean differences is shown. For individual contrasts, use \code{summary}.
 ##' @param noSpaces Whether to remove spaces added for alignment. Use this option if you prefer to align numbers yourself in other software.

--- a/R/print.svyCatTable.R
+++ b/R/print.svyCatTable.R
@@ -8,7 +8,7 @@
 ##' @param quote Whether to show everything in quotes. The default is FALSE. If TRUE, everything including the row and column names are quoted so that you can copy it to Excel easily.
 ##' @param missing Whether to show missing data information.
 ##' @param explain Whether to add explanation to the variable names, i.e., (\%) is added to the variable names when percentage is shown.
-##' @param printToggle Whether to print the output. If FLASE, no output is created, and a matrix is invisibly returned.
+##' @param printToggle Whether to print the output. If FALSE, no output is created, and a matrix is invisibly returned.
 ##' @param noSpaces Whether to remove spaces added for alignment. Use this option if you prefer to align numbers yourself in other software.
 ##' @param format The default is "fp" frequency (percentage). You can also choose from "f" frequency only, "p" percentage only, and "pf" percentage (frequency).
 ##' @param showAllLevels Whether to show all levels. FALSE by default, i.e., for 2-level categorical variables, only the higher level is shown to avoid redundant information.

--- a/R/print.svyContTable.R
+++ b/R/print.svyContTable.R
@@ -8,7 +8,7 @@
 ##' @param quote Whether to show everything in quotes. The default is FALSE. If TRUE, everything including the row and column names are quoted so that you can copy it to Excel easily.
 ##' @param missing Whether to show missing data information.
 ##' @param explain Whether to add explanation to the variable names, i.e., (mean (sd) or median [IQR]) is added to the variable names.
-##' @param printToggle Whether to print the output. If FLASE, no output is created, and a matrix is invisibly returned.
+##' @param printToggle Whether to print the output. If FALSE, no output is created, and a matrix is invisibly returned.
 ##' @param noSpaces Whether to remove spaces added for alignment. Use this option if you prefer to align numbers yourself in other software.
 ##' @param nonnormal A character vector to specify the variables for which the p-values should be those of nonparametric tests. By default all p-values are from normal assumption-based tests (oneway.test).
 ##' @param minMax Whether to use [min,max] instead of [p25,p75] for nonnormal variables. The default is FALSE.

--- a/man/ShowRegTable.Rd
+++ b/man/ShowRegTable.Rd
@@ -16,7 +16,7 @@ ShowRegTable(model, exp = TRUE, digits = 2, pDigits = 3,
 
 \item{pDigits}{Number of digits to print for the p-values.}
 
-\item{printToggle}{Whether to print the output. If FLASE, no output is created, and a matrix is invisibly returned.}
+\item{printToggle}{Whether to print the output. If FALSE, no output is created, and a matrix is invisibly returned.}
 
 \item{quote}{Whether to show everything in quotes. The default is FALSE. If TRUE, everything including the row and column names are quoted so that you can copy it to Excel easily.}
 

--- a/man/print.CatTable.Rd
+++ b/man/print.CatTable.Rd
@@ -23,7 +23,7 @@
 
 \item{explain}{Whether to add explanation to the variable names, i.e., (\%) is added to the variable names when percentage is shown.}
 
-\item{printToggle}{Whether to print the output. If FLASE, no output is created, and a matrix is invisibly returned.}
+\item{printToggle}{Whether to print the output. If FALSE, no output is created, and a matrix is invisibly returned.}
 
 \item{noSpaces}{Whether to remove spaces added for alignment. Use this option if you prefer to align numbers yourself in other software.}
 

--- a/man/print.ContTable.Rd
+++ b/man/print.ContTable.Rd
@@ -22,7 +22,7 @@
 
 \item{explain}{Whether to add explanation to the variable names, i.e., (mean (sd) or median [IQR]) is added to the variable names.}
 
-\item{printToggle}{Whether to print the output. If FLASE, no output is created, and a matrix is invisibly returned.}
+\item{printToggle}{Whether to print the output. If FALSE, no output is created, and a matrix is invisibly returned.}
 
 \item{noSpaces}{Whether to remove spaces added for alignment. Use this option if you prefer to align numbers yourself in other software.}
 

--- a/man/print.TableOne.Rd
+++ b/man/print.TableOne.Rd
@@ -26,7 +26,7 @@
 
 \item{explain}{Whether to add explanation to the variable names, i.e., (\%) is added to the variable names when percentage is shown.}
 
-\item{printToggle}{Whether to print the output. If FLASE, no output is created, and a matrix is invisibly returned.}
+\item{printToggle}{Whether to print the output. If FALSE, no output is created, and a matrix is invisibly returned.}
 
 \item{test}{Whether to show p-values. TRUE by default. If FALSE, only the numerical summaries are shown.}
 

--- a/man/print.svyCatTable.Rd
+++ b/man/print.svyCatTable.Rd
@@ -23,7 +23,7 @@
 
 \item{explain}{Whether to add explanation to the variable names, i.e., (\%) is added to the variable names when percentage is shown.}
 
-\item{printToggle}{Whether to print the output. If FLASE, no output is created, and a matrix is invisibly returned.}
+\item{printToggle}{Whether to print the output. If FALSE, no output is created, and a matrix is invisibly returned.}
 
 \item{noSpaces}{Whether to remove spaces added for alignment. Use this option if you prefer to align numbers yourself in other software.}
 

--- a/man/print.svyContTable.Rd
+++ b/man/print.svyContTable.Rd
@@ -22,7 +22,7 @@
 
 \item{explain}{Whether to add explanation to the variable names, i.e., (mean (sd) or median [IQR]) is added to the variable names.}
 
-\item{printToggle}{Whether to print the output. If FLASE, no output is created, and a matrix is invisibly returned.}
+\item{printToggle}{Whether to print the output. If FALSE, no output is created, and a matrix is invisibly returned.}
 
 \item{noSpaces}{Whether to remove spaces added for alignment. Use this option if you prefer to align numbers yourself in other software.}
 


### PR DESCRIPTION
@kaz-yos I was using your (awesome! :tada:) package tonight and noticed a few times the word `FALSE` was spelled wrong, so I thought I'd let you know. As an aside, I recently found out about roxygen templates for when you have certain `@params` that are used multiple times if you have some down time, you may want to check them out! Here is an example of [a template](https://github.com/tidyverse/googledrive/blob/master/man-roxygen/dots-metadata.R) and [here it is in use](https://github.com/tidyverse/googledrive/blob/master/R/drive_mkdir.R#L14).