### PR TITLE
Move lmerTest to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,6 @@ Imports:
     zoo,
     gmodels,
     nlme,
-    lmerTest,
     labelled
 Suggests:
     survival,
@@ -40,6 +39,7 @@ Suggests:
     knitr,
     geepack,
     lme4,
+    lmerTest,
     rmarkdown
 URL: https://github.com/kaz-yos/tableone
 VignetteBuilder: knitr

--- a/R/lmerTest_utils.R
+++ b/R/lmerTest_utils.R
@@ -1,12 +1,16 @@
 ## Minimized version of the helper function provided by lmerTest authors.
 lmerTest_summary <- function(object, ...) {
-    if (inherits(object, "lmerModLmerTest")) {
-        ## lmerTest object
+    if (requireNamespace("lmerTest", quietly = TRUE)) {
+        if (inherits(object, "lmerModLmerTest")) {
+            ## lmerTest object
+            return(summary(object, ...))
+        } else {
+            ## lme4 object
+            return(summary(lmerTest::as_lmerModLmerTest(object), ...))
+        }
+        ## *merModLmerTest objects and/or 'lmerTest' is not available
         return(summary(object, ...))
     } else {
-        ## lme4 object
-        return(summary(lmerTest::as_lmerModLmerTest(object), ...))
+        stop("ShowRegTable: Please install the package \"lmerTest\":\n install.package('lmerTest')", call. = F)
     }
-    ## *merModLmerTest objects and/or 'lmerTest' is not available
-    return(summary(object, ...))
 }


### PR DESCRIPTION
Hi @kaz-yos,

because of #58 I had a look at the dependencies. It seems that `lmerTest` could be optional, since objects of class `merModLmerTest` or `lmerModLmerTest` can probably only be created by `lmerTest` in the first place. Nevertheless, I added a check to `lmerTest_summary()` just to be safe.

I don't know if you consider this unneeded optimization, so feel free to reject this PR. The installed size of tableone would drop from ~83Mb to 55Mb (minus shared dependencies).

Greetings
Alex