### PR TITLE
Capturing, the print arguments

### DIFF
--- a/R/kableone.R
+++ b/R/kableone.R
@@ -17,6 +17,6 @@
 #' 
 #' @importFrom utils capture.output
 kableone <- function(x, ...) {
-  capture.output(x <- print(x))
+  capture.output(x <- print(x, ...))
   knitr::kable(x, ...)
 }


### PR DESCRIPTION
Hello,
I was using Tableone  and   it was (for my analysis) importatnt to show the missing (NA) observations 
Tableone only print this info when taking the agument (showAllLevels = TRUE) in the print function so it was missing when using kableone to knit the table 
add the points captures (showAllLevels = TRUE) when i run it