### PR TITLE
Added ci = FALSE to svyquantile function

### DIFF
--- a/R/modules-svy.R
+++ b/R/modules-svy.R
@@ -117,7 +117,7 @@ svyQuant <- function(vars, design, q = 0.5) {
     res <- vector()
     for ( i in 1:length(vars)) {
       var    <- vars[i]
-      res[i] <- svyquantile(design$variables[var], design = design, quantiles = q[1], na.rm = TRUE)
+      res[i] <- svyquantile(design$variables[var], design = design, quantiles = q[1], na.rm = TRUE, ci = FALSE)
     }
     out <- as.vector(res)
     names(out) <- vars


### PR DESCRIPTION
Hi Kazuki,

I too came across issue #83.  As noted by, @docvock, the source of the problem is that survey updated the default output of the svyquantile function.  Here's further elaboration:

The previous default input for svyquantile was ci=FALSE.  Now it is ci=TRUE.

survey(version 4.0): https://www.rdocumentation.org/packages/survey/versions/4.0/topics/svyquantile
survey(version 4.1): https://rdrr.io/cran/survey/man/svyquantile.html

Under survey (v4.1), svyQuant (within tableone) returns a quantile, 95% ci, and standard error (a numeric vector of size 4) for each variable.  Previously, svyQuant only returned a quantile (singleton) for each variable.

As a downstream effect, the error regarding rounding occurs when updating the class of the result object (created within svyCreateContTable).  I was not able to track down why this particular error occurred.  However, the proposed pull request resolves the original problem by setting ci = FALSE when calling svyquantile (within tableone::svyQuant).

I tested the updates using the NHANES example within ?svyCreateTableOne.

I hope you are well and best wishes,

Jonathan Chipman